### PR TITLE
Added fix for File::Pwd()

### DIFF
--- a/src/File.cpp
+++ b/src/File.cpp
@@ -594,9 +594,9 @@ twine File::Pwd()
 	ret.reserve( 4096 );
 	char* checkptr;
 #ifdef _WIN32
-	checkptr = _getcwd( ret.data(), (int)ret.size() );
+	checkptr = _getcwd( ret.data(), (int)ret.capacity() );
 #else
-	checkptr = getcwd( ret.data(), ret.size() );
+	checkptr = getcwd( ret.data(), ret.capacity() );
 #endif
 	if(checkptr == NULL){
 		if(errno == EINVAL){


### PR DESCRIPTION
Changed ret.size() call to ret.capacity() call. This returns the
m_allocated_size - 1, rather than the m_data_size, which is usually 0
for a new twine.